### PR TITLE
Release v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v1.2.6 - 2026-04-15
+
+### Bug Fixes
+
+- Respect `pocketMock({ enable: false })` and skip initialization when disabled.
+- Prevent repeated `fetch` and `XMLHttpRequest` patching when `pocketMock()` is called multiple times.
+- Preserve falsy primitive values such as `0`, `false`, and empty strings in request/response log formatting.
+- Validate Vite plugin save payloads before writing `pocket-mock.json`, returning `400` for invalid JSON without overwriting existing config.
+
+### Tests
+
+- Added regression tests for interceptor patch idempotency.
+- Added regression tests for invalid Vite plugin config saves.
+- Added coverage for falsy primitive JSON formatting.
+
+---
+
 ## v1.2.5 - 2026-01-13
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pocket-mocker",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pocket-mocker",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pocket-mocker",
   "description": "Visual in-browser HTTP mocking tool for modern frontend development",
   "private": false,
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "keywords": [
     "mock",

--- a/plugin/vite-plugin-pocket-mock.js
+++ b/plugin/vite-plugin-pocket-mock.js
@@ -87,17 +87,19 @@ export default function pocketMockPlugin() {
           req.on('end', () => {
             try {
               const configPath = path.resolve(process.cwd(), CONFIG_FILE_NAME);
-              fs.writeFileSync(configPath, body);
+              const parsed = JSON.parse(body);
+              fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2));
 
               res.statusCode = 200;
               res.setHeader('Content-Type', 'application/json');
               res.end(JSON.stringify({ success: true }));
               
             } catch (e) {
-              console.error('[PocketMock] Save failed', e);
-              res.statusCode = 500;
+              const isSyntaxError = e instanceof SyntaxError;
+              console.error(isSyntaxError ? '[PocketMock] Invalid config JSON' : '[PocketMock] Save failed', e);
+              res.statusCode = isSyntaxError ? 400 : 500;
               res.setHeader('Content-Type', 'application/json');
-              res.end(JSON.stringify({ error: 'Save failed' }));
+              res.end(JSON.stringify({ error: isSyntaxError ? 'Invalid JSON' : 'Save failed' }));
             }
           });
           return; 

--- a/src/core/adapters/fetch.ts
+++ b/src/core/adapters/fetch.ts
@@ -2,10 +2,18 @@ import { appReady } from '@/store/store';
 import { parseBodyData } from '../utils/http';
 import { findMatchingRule, resolveMockResponse, logMockRequest } from '../engine/handler';
 
+type PatchedFetch = typeof window.fetch & {
+  __pocketMockPatched?: true;
+  __pocketMockOriginalFetch?: typeof window.fetch;
+};
+
 export function patchFetch() {
+  const currentFetch = window.fetch as PatchedFetch;
+  if (currentFetch.__pocketMockPatched) return;
+
   const originalFetch = window.fetch;
 
-  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const pocketFetch: PatchedFetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string' ? input : (input instanceof Request ? input.url : input.toString());
 
     if (url.includes('/__pocket_mock/')) {
@@ -68,4 +76,8 @@ export function patchFetch() {
 
     return promise;
   };
+
+  pocketFetch.__pocketMockPatched = true;
+  pocketFetch.__pocketMockOriginalFetch = originalFetch;
+  window.fetch = pocketFetch;
 }

--- a/src/core/adapters/xhr.ts
+++ b/src/core/adapters/xhr.ts
@@ -2,7 +2,15 @@ import { appReady } from '@/store/store';
 import { parseBodyData } from '../utils/http';
 import { findMatchingRule, resolveMockResponse, logMockRequest } from '../engine/handler';
 
+type PatchedXMLHttpRequest = typeof window.XMLHttpRequest & {
+  __pocketMockPatched?: true;
+  __pocketMockOriginalXHR?: typeof window.XMLHttpRequest;
+};
+
 export function patchXHR() {
+  const CurrentXHR = window.XMLHttpRequest as PatchedXMLHttpRequest;
+  if (CurrentXHR.__pocketMockPatched) return;
+
   const OriginalXHR = window.XMLHttpRequest;
 
   class PocketXHR extends OriginalXHR {
@@ -137,5 +145,7 @@ export function patchXHR() {
     }
   }
 
+  (PocketXHR as PatchedXMLHttpRequest).__pocketMockPatched = true;
+  (PocketXHR as PatchedXMLHttpRequest).__pocketMockOriginalXHR = OriginalXHR;
   window.XMLHttpRequest = PocketXHR;
 }

--- a/src/core/utils/http.ts
+++ b/src/core/utils/http.ts
@@ -1,5 +1,5 @@
 export function formatJSON(response: any): string | undefined {
-  if (!response) return undefined;
+  if (response === null || response === undefined) return undefined;
 
   if (typeof response === 'string') {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ export function defineConfig(config: MockRule[]): MockRule[] {
 }
 
 export function pocketMock(options: PocketMockOptions = {}) {
+  if (options.enable === false) return;
+
   initInterceptor();
   initStore();
   mountUI();

--- a/test/core/adapters/patch.test.ts
+++ b/test/core/adapters/patch.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/store/store', () => ({
+  appReady: Promise.resolve()
+}));
+
+vi.mock('../../../src/core/engine/handler', () => ({
+  findMatchingRule: vi.fn(),
+  resolveMockResponse: vi.fn(),
+  logMockRequest: vi.fn()
+}));
+
+describe('HTTP adapter patching', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('window', {
+      fetch: vi.fn(),
+      XMLHttpRequest: class XMLHttpRequest {}
+    });
+  });
+
+  it('should patch fetch only once', async () => {
+    const { patchFetch } = await import('../../../src/core/adapters/fetch');
+
+    const originalFetch = window.fetch;
+    patchFetch();
+    const patchedFetch = window.fetch as any;
+    patchFetch();
+
+    expect(window.fetch).toBe(patchedFetch);
+    expect(patchedFetch).not.toBe(originalFetch);
+    expect(patchedFetch.__pocketMockPatched).toBe(true);
+    expect(patchedFetch.__pocketMockOriginalFetch).toBe(originalFetch);
+  });
+
+  it('should patch XMLHttpRequest only once', async () => {
+    const { patchXHR } = await import('../../../src/core/adapters/xhr');
+
+    const OriginalXHR = window.XMLHttpRequest;
+    patchXHR();
+    const PatchedXHR = window.XMLHttpRequest as any;
+    patchXHR();
+
+    expect(window.XMLHttpRequest).toBe(PatchedXHR);
+    expect(PatchedXHR).not.toBe(OriginalXHR);
+    expect(PatchedXHR.__pocketMockPatched).toBe(true);
+    expect(PatchedXHR.__pocketMockOriginalXHR).toBe(OriginalXHR);
+  });
+});

--- a/test/core/utils/http.test.ts
+++ b/test/core/utils/http.test.ts
@@ -28,6 +28,12 @@ describe('HTTP Utils', () => {
       const payload = [{ a: 1 }, { b: 2 }];
       expect(formatJSON(payload)).toBe(JSON.stringify(payload, null, 2));
     });
+
+    it('should preserve falsy primitive values', () => {
+      expect(formatJSON(0)).toBe('0');
+      expect(formatJSON(false)).toBe('false');
+      expect(formatJSON('')).toBe('');
+    });
   });
 
   describe('formatHeaders', () => {

--- a/test/plugin/vite-plugin-pocket-mock.test.ts
+++ b/test/plugin/vite-plugin-pocket-mock.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import pocketMockPlugin from '../../plugin/vite-plugin-pocket-mock.js';
+
+type Middleware = (req: any, res: any, next: () => void) => void;
+
+const originalCwd = process.cwd();
+let tempDir = '';
+
+function createMiddleware() {
+  let middleware: Middleware | undefined;
+  const plugin = pocketMockPlugin();
+  plugin.configureServer({
+    middlewares: {
+      use(fn: Middleware) {
+        middleware = fn;
+      }
+    }
+  });
+  if (!middleware) throw new Error('Middleware was not registered');
+  return middleware;
+}
+
+function createResponse() {
+  let resolveEnd!: () => void;
+  const ended = new Promise<void>((resolve) => {
+    resolveEnd = resolve;
+  });
+
+  const res = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: '',
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+    end(body?: string) {
+      this.body = body || '';
+      resolveEnd();
+    },
+    ended
+  };
+
+  return res;
+}
+
+async function postSave(body: string) {
+  const middleware = createMiddleware();
+  const req = new EventEmitter() as any;
+  req.url = '/__pocket_mock/save';
+  req.method = 'POST';
+
+  const res = createResponse();
+  const next = vi.fn();
+
+  middleware(req, res, next);
+  req.emit('data', Buffer.from(body));
+  req.emit('end');
+  await res.ended;
+
+  return { res, next };
+}
+
+describe('vite-plugin-pocket-mock', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pocket-mock-test-'));
+    process.chdir(tempDir);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should save valid JSON in a formatted config file', async () => {
+    const { res, next } = await postSave('{"rules":[],"groups":[]}');
+    const configPath = path.join(tempDir, 'pocket-mock.json');
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true });
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe(JSON.stringify({ rules: [], groups: [] }, null, 2));
+  });
+
+  it('should reject invalid JSON without overwriting the config file', async () => {
+    const configPath = path.join(tempDir, 'pocket-mock.json');
+    fs.writeFileSync(configPath, '{"rules":[]}');
+
+    const { res } = await postSave('{invalid');
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid JSON' });
+    expect(fs.readFileSync(configPath, 'utf-8')).toBe('{"rules":[]}');
+  });
+});


### PR DESCRIPTION
## Summary
- harden PocketMock initialization with enable=false support and idempotent fetch/XHR patching
- preserve falsy primitive values in request/response log formatting
- validate Vite plugin config saves before writing pocket-mock.json
- bump package version to 1.2.6 and add changelog notes

## Validation
- npm test -- --run
- npm run check
- npm run build

## Release note
The v1.2.6 tag was already pushed and triggered the Release workflow, but npm publish failed with E404, likely because the GitHub Actions NPM_TOKEN lacks publish permission for pocket-mocker. After this PR is merged and NPM_TOKEN is fixed, rerun the Release workflow or recreate the tag from main if needed.